### PR TITLE
user does not rely on tenant to be created

### DIFF
--- a/src/main/java/com/deydey/iam/application/service/RegistrationService.java
+++ b/src/main/java/com/deydey/iam/application/service/RegistrationService.java
@@ -41,7 +41,7 @@ public class RegistrationService {
 	// NOTE: breaking aggregate transactional boundaries due to tenant/user mappings
 	public RegistrationDto registerUserAsTenant(CreateRegistrationCommand createRegistrationCommand) {
 		Tenant tenant = Tenant.newPersonalTenant(createRegistrationCommand);
-		User user = User.of(tenant.getTenantId(), createRegistrationCommand);
+		User user = User.of(createRegistrationCommand);
 		Member member = Member.of(user.getId(),
 				tenant.getTenantId(),
 				createRegistrationCommand,

--- a/src/main/java/com/deydey/iam/domain/identity/user/User.java
+++ b/src/main/java/com/deydey/iam/domain/identity/user/User.java
@@ -24,16 +24,10 @@ public class User {
 	private UserIdentityInformation userIdentityInformation;
 	@Getter
 	private AuditInformation auditInformation;
-	@Getter
-	@Setter
-	private TenantId tenantId;
-
 	private List<Member> members;
 
-	public static User of(TenantId tenantId,
-						CreateRegistrationCommand createRegistrationCommand) {
+	public static User of(CreateRegistrationCommand createRegistrationCommand) {
 		return User.builder()
-				.tenantId(tenantId)
 				.userIdentityInformation(
 					new UserIdentityInformation(createRegistrationCommand.getFirstName(),
 						createRegistrationCommand.getLastName(),

--- a/src/main/java/com/deydey/iam/infrastructure/persistence/jdbc/repositories/UserJdbcRepository.java
+++ b/src/main/java/com/deydey/iam/infrastructure/persistence/jdbc/repositories/UserJdbcRepository.java
@@ -1,7 +1,6 @@
 package com.deydey.iam.infrastructure.persistence.jdbc.repositories;
 
 import com.deydey.common.infrastructure.persistence.AuditInformation;
-import com.deydey.iam.domain.identity.tenant.TenantId;
 import com.deydey.iam.domain.identity.user.Member;
 import com.deydey.iam.domain.identity.user.User;
 import com.deydey.iam.domain.identity.user.UserId;
@@ -22,8 +21,8 @@ import java.util.UUID;
 public class UserJdbcRepository implements UserRepository {
 
 	private final String SAVE_USER = "INSERT INTO users" +
-			"(id, tenant_id, first_name, last_name, default_email, created_at, updated_at) VALUES" +
-			"(:id, :tenantId, :firstName, :lastName, :defaultEmail, :createdAt, :updatedAt);";
+			"(id, first_name, last_name, default_email, created_at, updated_at) VALUES" +
+			"(:id, :firstName, :lastName, :defaultEmail, :createdAt, :updatedAt);";
 	private final String GET_USER_BY_ID = "select * from users where id = :userId";
 	private final String GET_USER_MEMBERS = "select * from member where user_id = :userId";
 
@@ -38,7 +37,6 @@ public class UserJdbcRepository implements UserRepository {
 		MapSqlParameterSource parameters = new JdbcMapParameterSource();
 		AuditInformationParameterInjection.injectParameters(parameters, user.getAuditInformation());
 		parameters.addValue("id", user.getId().getValue());
-		parameters.addValue("tenantId", user.getTenantId().getValue());
 		parameters.addValue("firstName", userIdentityInformation.getFirstName());
 		parameters.addValue("lastName", userIdentityInformation.getLastName());
 		parameters.addValue("defaultEmail", userIdentityInformation.getDefaultEmail());
@@ -76,7 +74,6 @@ public class UserJdbcRepository implements UserRepository {
 						.createdAt(rs.getTimestamp("created_at").toInstant())
 						.updatedAt(rs.getTimestamp("updated_at").toInstant())
 						.build())
-				.tenantId(new TenantId(UUID.fromString(rs.getString("tenant_id"))))
 				.userIdentityInformation(
 						new UserIdentityInformation(rs.getString("default_email"),
 							rs.getString("first_name"),

--- a/src/main/resources/db/migration/V1__init_user.sql
+++ b/src/main/resources/db/migration/V1__init_user.sql
@@ -13,7 +13,6 @@ CREATE TABLE tenant (
 
 CREATE TABLE users (
     id uuid NOT NULL,
-    tenant_id uuid NOT NULL references tenant (id) on delete cascade,
     default_email varchar(250) NOT NULL,
     first_name varchar(250),
     last_name varchar(250),

--- a/src/test-integration/groovy/com/deydey/iam/infrastructure/jdbc/MemberRepositoryIntTest.groovy
+++ b/src/test-integration/groovy/com/deydey/iam/infrastructure/jdbc/MemberRepositoryIntTest.groovy
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import static com.deydey.iam.testFactory.MemberTestFactory.aMember
 import static com.deydey.iam.testFactory.TenantTestFactory.aPersonalTenant
 import static com.deydey.iam.testFactory.UUIDGenerator.uuid
-import static com.deydey.iam.testFactory.UserTestFactory.aUser
+import static com.deydey.iam.testFactory.UserTestFactory.aUserOf
 
 class MemberRepositoryIntTest extends DatabaseIntegrationTest {
 
@@ -51,6 +51,6 @@ class MemberRepositoryIntTest extends DatabaseIntegrationTest {
     }
 
     def saveAUser() {
-        userRepository.save(aUser([tenantId: tenantId, userId: userId]))
+        userRepository.save(aUserOf([userId: userId]))
     }
 }

--- a/src/test-integration/groovy/com/deydey/iam/testFactory/UserTestFactory.groovy
+++ b/src/test-integration/groovy/com/deydey/iam/testFactory/UserTestFactory.groovy
@@ -1,16 +1,14 @@
 package com.deydey.iam.testFactory
 
 import com.deydey.iam.application.command.registration.CreateRegistrationCommand
-import com.deydey.iam.domain.identity.tenant.TenantId
 import com.deydey.iam.domain.identity.user.User
 import com.deydey.iam.domain.identity.user.UserId
 
 import static com.deydey.iam.testFactory.CreateRegistrationCommendTestFactory.aCreateRegistrationCommand
-import static com.deydey.iam.testFactory.UUIDGenerator.uuid
 
 class UserTestFactory {
-    static User aUser(Map params = [:]) {
-        User user = User.of(params.tenantId as TenantId ?: new TenantId(uuid()),
+    static User aUserOf(Map params = [:]) {
+        User user = User.of(
             params.createRegistrationCommand as CreateRegistrationCommand ?: aCreateRegistrationCommand())
         if (params.userId) {
             user.setId(params.userId as UserId)

--- a/src/test/groovy/com/deydey/iam/infrastructure/persistence/jdbc/repositories/MemberRepositoryUnitTest.groovy
+++ b/src/test/groovy/com/deydey/iam/infrastructure/persistence/jdbc/repositories/MemberRepositoryUnitTest.groovy
@@ -15,6 +15,7 @@ import static java.util.Arrays.asList
 import static com.deydey.iam.testFactory.UUIDGenerator.uuid
 import static com.deydey.iam.testFactory.MemberTestFactory.aMember
 import static com.deydey.iam.testFactory.UserTestFactory.aUser
+import static com.deydey.iam.testFactory.UserTestFactory.aUserOf
 import static com.deydey.iam.testFactory.TenantTestFactory.aPersonalTenant
 
 class MemberRepositoryUnitTest extends Specification {
@@ -29,9 +30,8 @@ class MemberRepositoryUnitTest extends Specification {
     def "member repository gets a member and hydrates the user and tenant id" () {
         given: "a user and a tenant"
             Tenant expectedTenant = aPersonalTenant()
-            User expectedUser = aUser([
+            User expectedUser = aUserOf([
                     userId: new UserId(uuid()),
-                    tenantId: expectedTenant.getTenantId()
             ])
         and: "an expected member without tenant and user id"
             Member expected = aMember()

--- a/src/test/groovy/com/deydey/iam/infrastructure/persistence/jdbc/repositories/UserRepositoryUnitTest.groovy
+++ b/src/test/groovy/com/deydey/iam/infrastructure/persistence/jdbc/repositories/UserRepositoryUnitTest.groovy
@@ -14,7 +14,7 @@ import javax.persistence.EntityNotFoundException
 
 import static com.deydey.iam.testFactory.UUIDGenerator.uuid
 import static com.deydey.iam.testFactory.MemberTestFactory.aMember
-import static com.deydey.iam.testFactory.UserTestFactory.aUser
+import static com.deydey.iam.testFactory.UserTestFactory.aUserOf
 import static java.util.Arrays.asList
 
 class UserRepositoryUnitTest extends Specification {
@@ -29,7 +29,7 @@ class UserRepositoryUnitTest extends Specification {
 
     def "user repository gets user by user id" () {
         given: "a user"
-            User expected = aUser([
+            User expected = aUserOf([
                 userId: new UserId(uuid())
             ])
         and: "a parameter query source"
@@ -52,7 +52,7 @@ class UserRepositoryUnitTest extends Specification {
 
     def "user repository throws exception for if user does not exist" () {
         given: "a user"
-        User expected = aUser([
+        User expected = aUserOf([
                 userId: new UserId(uuid())
         ])
         and: "a parameter query source"

--- a/src/test/groovy/com/deydey/iam/testFactory/UserTestFactory.groovy
+++ b/src/test/groovy/com/deydey/iam/testFactory/UserTestFactory.groovy
@@ -9,8 +9,8 @@ import static com.deydey.iam.testFactory.CreateRegistrationCommendTestFactory.aC
 import static com.deydey.iam.testFactory.UUIDGenerator.uuid
 
 class UserTestFactory {
-    static User aUser(Map params = [:]) {
-        User user = User.of(params.tenantId as TenantId ?: new TenantId(uuid()),
+    static User aUserOf(Map params = [:]) {
+        User user = User.of(
             params.createRegistrationCommand as CreateRegistrationCommand ?: aCreateRegistrationCommand())
         if (params.userId) {
             user.setId(params.userId as UserId)


### PR DESCRIPTION
A `User`'s `Members` are related to the tenant uniquely. It must reach through member for authentication, and for the translation layer to translate it to spring user details, granted authorities, and credentials.